### PR TITLE
Move the compliance and kyc status fields into payeedata.

### DIFF
--- a/umad-04-lnurlp-response.md
+++ b/umad-04-lnurlp-response.md
@@ -50,6 +50,7 @@ The full structure of the LNURLP response is:
   // UMA-specific authentication and compliance info.
   "compliance" {
     "isSubjectToTravelRule": boolean, // true if VASP2 needs travel rule info
+    "kycStatus": KycStatus, // [enum] KYC state indicating whether the receiver is a KYC'd customer of VASP2.
     "signature": string, // hex encoded
     "signatureNonce": string,
     "signatureTimestamp": number, // secs since epoch

--- a/umad-04-lnurlp-response.md
+++ b/umad-04-lnurlp-response.md
@@ -50,11 +50,10 @@ The full structure of the LNURLP response is:
   // UMA-specific authentication and compliance info.
   "compliance" {
     "isSubjectToTravelRule": boolean, // true if VASP2 needs travel rule info
-    "kycStatus": KycStatus, // [enum] KYC state indicating whether the receiver is a KYC'd customer of VASP2.
     "signature": string, // hex encoded
     "signatureNonce": string,
-    "signatureTimestamp": number // secs since epoch
-    "receiverIdentifier": string // The identity of the receiver at VASP2
+    "signatureTimestamp": number, // secs since epoch
+    "receiverIdentifier": string, // The identity of the receiver at VASP2
   },
   "umaVersion": "1.0", // The UMA protocol version that will be used for this transaction.
   "tag": "payRequest",

--- a/umad-05-payreq-request.md
+++ b/umad-05-payreq-request.md
@@ -33,6 +33,7 @@ The body of the request is a JSON object with the following fields:
   // The UMA protocol version that will be used for this transaction. See [UMAD-08](/umad-08-versioning.md).
   "umaVersion": "1.0",
   "payeeData":  {
+    "compliance": { "mandatory": boolean },
     "name": { "mandatory": boolean },
     "identifier": { "mandatory": boolean },
     "countryCode": { "mandatory": boolean },

--- a/umad-06-payreq-response.md
+++ b/umad-06-payreq-response.md
@@ -10,20 +10,6 @@ The full structure of the LNURLP response is:
   "pr": string,
   // Empty for legcy LNURL reasons.
   "routes": [],
-  "compliance": {
-    // Public key of the recipient node for pre-screening.
-    "nodePubKey": string,
-    // A list of the expected UTXOs over which the receiver may receive the transaction (receiver's channels).
-    "utxos": string[],
-    // A url which the sending VASP should call on transaction completion to notify the receiving VASP of
-    // the utxos used to complete the transaction. See [UMAD-07](/umad-07-post-tx-hooks.md).
-    "utxoCallback": string,
-    // The receiving VASP's signature over sha256_hash(<sender UMA> (eg. $alice@vasp1.com) + <receiver UMA> (eg. $bob@vasp2.com) +
-    // signatureNonce + signatureTimestamp)
-    "signature": string,
-    "signatureNonce": string,
-    "signatureTimestamp": number, // in seconds since epoch
-  },
   "converted": {
     // The amount that the receiver will receive in the receiving currency not including fees. The amount is specified
     // in the smallest unit of the currency (eg. cents for USD).
@@ -45,6 +31,22 @@ The full structure of the LNURLP response is:
     "fee": number
   },
   "payeeData": {
+    "compliance": {
+      // [enum] KYC state indicating whether the receiver is a KYC'd customer of VASP2.
+      "kycStatus": KycStatus,
+      // Public key of the recipient node for pre-screening.
+      "nodePubKey": string,
+      // A list of the expected UTXOs over which the receiver may receive the transaction (receiver's channels).
+      "utxos": string[],
+      // A url which the sending VASP should call on transaction completion to notify the receiving VASP of
+      // the utxos used to complete the transaction. See [UMAD-07](/umad-07-post-tx-hooks.md).
+      "utxoCallback": string,
+      // The receiving VASP's signature over sha256_hash(<sender UMA> (eg. $alice@vasp1.com) + <receiver UMA> (eg. $bob@vasp2.com) +
+      // signatureNonce + signatureTimestamp)
+      "signature": string,
+      "signatureNonce": string,
+      "signatureTimestamp": number, // in seconds since epoch
+    },
     "name": string,
     "identifier": string,
     "countryCode": string,

--- a/umad-06-payreq-response.md
+++ b/umad-06-payreq-response.md
@@ -32,8 +32,6 @@ The full structure of the LNURLP response is:
   },
   "payeeData": {
     "compliance": {
-      // [enum] KYC state indicating whether the receiver is a KYC'd customer of VASP2.
-      "kycStatus": KycStatus,
       // Public key of the recipient node for pre-screening.
       "nodePubKey": string,
       // A list of the expected UTXOs over which the receiver may receive the transaction (receiver's channels).


### PR DESCRIPTION
This better matches the use of payeedata and how payerdata already works.