### PR TITLE
Use named form for openssl key generation

### DIFF
--- a/umad-02-keys-and-authentication.md
+++ b/umad-02-keys-and-authentication.md
@@ -11,7 +11,7 @@ to create secp256k1 keys using openssl, run:
 
 ```bash
 # Generate a secp256k1 key:
-$ openssl ecparam -genkey -name secp256k1 -out ec_key.pem -param_enc explicit
+$ openssl ecparam -genkey -name secp256k1 -out ec_key.pem
 
 # Print out the key data:
 $ openssl ec -in ec_key.pem -noout -text


### PR DESCRIPTION
java x509 certs (and potentially js) require named curve parameters instead of explicit